### PR TITLE
Griptape-28

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ In this example, we're using three `Image Description` nodes to describe the giv
 ### July 10, 2024
 
 * Updated to work with Griptape v0.28.0
+* Image Description node now can handle multiple images at once, and works with Open Source llava.
 * Fixed tool, config, ruleset, memory bugs for creating agents based on update to v0.28.0
 * **New Nodes** Added WebSearch Drivers: DuckDuckGo and Google Search. To use Google Search, you must have two API keys - GOOGLE_API_KEY and GOOGLE_API_SEARCH_ID. 
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ In this example, we're using three `Image Description` nodes to describe the giv
 
 ### July 10, 2024
 
-* Updated to work with Griptape v0.28.0
+* Updated to work with Griptape v0.28.1
 * Image Description node now can handle multiple images at once, and works with Open Source llava.
 * Fixed tool, config, ruleset, memory bugs for creating agents based on update to v0.28.0
 * **New Nodes** Added WebSearch Drivers: DuckDuckGo and Google Search. To use Google Search, you must have two API keys - GOOGLE_API_KEY and GOOGLE_API_SEARCH_ID. 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ In this example, we're using three `Image Description` nodes to describe the giv
 ## Recent Changelog
 
 ### July 10, 2024
+
 * Updated to work with Griptape v0.28.0
-* Added WebSearch Drivers: DuckDuckGo and Google Search. To use Google Search, you must have two API keys - GOOGLE_API_KEY and GOOGLE_API_SEARCH_ID.
+* Fixed tool, config, ruleset, memory bugs for creating agents based on update to v0.28.0
+* **New Nodes** Added WebSearch Drivers: DuckDuckGo and Google Search. To use Google Search, you must have two API keys - GOOGLE_API_KEY and GOOGLE_API_SEARCH_ID. 
 
 ### July 9, 2024
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ In this example, we're using three `Image Description` nodes to describe the giv
 
 ## Recent Changelog
 
+### July 10, 2024
+* Updated to work with Griptape v0.28.0
+* Added WebSearch Drivers: DuckDuckGo and Google Search. To use Google Search, you must have two API keys - GOOGLE_API_KEY and GOOGLE_API_SEARCH_ID.
+
 ### July 9, 2024
 
 * Updated LMStudio and Ollama config nodes to use 127.0.0.1

--- a/__init__.py
+++ b/__init__.py
@@ -69,6 +69,10 @@ from .nodes.tools import (
     gtUIWebScraper,
     gtUIWebSearch,
 )
+from .nodes.websearch_drivers import (
+    gtUIDuckDuckGoWebSearchDriver,
+    gtUIGoogleWebSearchDriver,
+)
 from .py.griptape_config import (
     load_and_prepare_config,
     set_environment_variables_from_config,
@@ -153,6 +157,9 @@ NODE_CLASS_MAPPINGS = {
     "Griptape Run: Audio Transcription": gtUIAudioTranscriptionTask,
     # AUDIO DRIVER
     "Griptape Audio Driver: OpenAI": gtUIOpenAiAudioTranscriptionDriver,
+    # WEBSEARCH DRIVERS
+    "Griptape Driver: DuckDuckGo WebSearch": gtUIDuckDuckGoWebSearchDriver,
+    "Griptape Driver: Google WebSearch": gtUIGoogleWebSearchDriver,
     # "Griptape Display: Artifact": gtUIOutputArtifactNode,
     # "Griptape Config: Environment Variables": gtUIEnv,
 }

--- a/js/gtUINodes.js
+++ b/js/gtUINodes.js
@@ -435,13 +435,14 @@ app.registerExtension({
   },
   async beforeRegisterNodeDef(nodeType, nodeData, app) {
 
-    // if (nodeData.category.startsWith("Griptape")) {
+    // if (nodeData.name.startsWith("Griptape")) {
     //   const origOnConfigure = nodeType.prototype.onConfigure;
     //   nodeType.prototype.onConfigure = function () {
-    //     this.bgcolor = "#171717";
-    //     this.color = getColor(nodeData.category);
-    //   };
+    //     this.bgcolor=LGraphCanvas.node_colors.yellow.bgcolor;
 
+    //     // this.color = getColor(nodeData.category);
+    //   };
+    // }
 
     // Configuration Nodes
     if (nodeData.name.includes("Griptape Agent Config")) {
@@ -538,7 +539,9 @@ app.registerExtension({
         this.message.inputEl.style.borderRadius = "8px";
         this.message.inputEl.style.padding  = "8px";
         this.message.inputEl.style.height = "100%";
+        
         fitHeight(this, true);
+       
         return me;
       }
      

--- a/nodes/agent/agent.py
+++ b/nodes/agent/agent.py
@@ -55,6 +55,26 @@ class gtComfyAgent(Agent):
         else:
             return f"This Agent Configuration Model: **{ self.config.prompt_driver.model }** may run into issues using tools.\n\nPlease consider using a different configuration, a different model, or removing tools from the agent and use the **Griptape Run: Tool Task** node for specific tool use."
 
+    def update_agent(
+        self,
+        config=None,
+        tools=None,
+        rulesets=None,
+        conversation_memory=None,
+        meta_memory=None,
+        task_memory=None,
+    ):
+        update_dict = {
+            "config": config or self.config,
+            "tools": tools or self.tools,
+            "rulesets": rulesets or self.rulesets,
+            "conversation_memory": conversation_memory or self.conversation_memory,
+            "meta_memory": meta_memory or self.meta_memory,
+            "task_memory": task_memory or self.task_memory,
+        }
+        new_agent = gtComfyAgent(**update_dict)
+        return new_agent
+
     def update_config(self, config):
         tools = self.tools
         rulesets = self.rulesets

--- a/nodes/base_tool.py
+++ b/nodes/base_tool.py
@@ -11,7 +11,10 @@ class gtUIBaseTool:
 
     @classmethod
     def INPUT_TYPES(s):
-        return {"required": {"off_prompt": ("BOOLEAN", {"default": False})}}
+        return {
+            "required": {"off_prompt": ("BOOLEAN", {"default": False})},
+            "optional": {},
+        }
 
     RETURN_TYPES = ("TOOL_LIST",)
     RETURN_NAMES = ("TOOL",)

--- a/nodes/base_websearch_driver.py
+++ b/nodes/base_websearch_driver.py
@@ -1,0 +1,23 @@
+from griptape.drivers import BaseWebSearchDriver
+
+
+class gtUIBaseWebSearchDriver:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {},
+            "optional": {},
+        }
+
+    RETURN_TYPES = ("DRIVER",)
+    RETURN_NAMES = ("DRIVER",)
+
+    FUNCTION = "create"
+
+    CATEGORY = "Griptape/Websearch Drivers"
+
+    def create(
+        self,
+    ):
+        driver = BaseWebSearchDriver()
+        return (driver,)

--- a/nodes/config_nodes.py
+++ b/nodes/config_nodes.py
@@ -1,5 +1,6 @@
 import os
 
+from griptape.common import PromptStack
 from griptape.config import (
     AmazonBedrockStructureConfig,
     AnthropicStructureConfig,
@@ -24,7 +25,6 @@ from griptape.drivers import (
     OpenAiImageQueryDriver,
 )
 from griptape.tokenizers import SimpleTokenizer
-from griptape.utils import PromptStack
 
 from ..py.griptape_config import get_config
 from .base_config import gtUIBaseConfig
@@ -77,7 +77,9 @@ lmstudio_base_url = "http://127.0.0.1"
 
 
 class LMStudioPromptDriver(OpenAiChatPromptDriver):
-    def _prompt_stack_input_to_message(self, prompt_input: PromptStack.Input) -> dict:
+    def _prompt_stack_input_to_message(
+        self, prompt_input: PromptStack.messages
+    ) -> dict:
         content = prompt_input.content
 
         if prompt_input.is_system():

--- a/nodes/config_nodes.py
+++ b/nodes/config_nodes.py
@@ -1,6 +1,5 @@
 import os
 
-from griptape.common import PromptStack
 from griptape.config import (
     AmazonBedrockStructureConfig,
     AnthropicStructureConfig,
@@ -24,7 +23,6 @@ from griptape.drivers import (
     OpenAiImageGenerationDriver,
     OpenAiImageQueryDriver,
 )
-from griptape.tokenizers import SimpleTokenizer
 
 from ..py.griptape_config import get_config
 from .base_config import gtUIBaseConfig
@@ -76,24 +74,6 @@ lmstudio_port = "1234"
 lmstudio_base_url = "http://127.0.0.1"
 
 
-class LMStudioPromptDriver(OpenAiChatPromptDriver):
-    def _prompt_stack_input_to_message(
-        self, prompt_input: PromptStack.messages
-    ) -> dict:
-        content = prompt_input.content
-
-        if prompt_input.is_system():
-            return {
-                "role": "system",
-                # "content": content, # This is the original line - it kept coming back blank
-                "content": "Always answer with integrity and never lie.",
-            }
-        elif prompt_input.is_assistant():
-            return {"role": "assistant", "content": content}
-        else:
-            return {"role": "user", "content": content}
-
-
 class gtUILMStudioStructureConfig(gtUIBaseConfig):
     """
     The Griptape LM Studio Structure Config
@@ -132,16 +112,11 @@ class gtUILMStudioStructureConfig(gtUIBaseConfig):
         image_generation_driver=DummyImageGenerationDriver(),
     ):
         custom_config = StructureConfig(
-            prompt_driver=LMStudioPromptDriver(
+            prompt_driver=OpenAiChatPromptDriver(
                 model=prompt_model,
                 base_url=f"{base_url}:{port}/v1",
                 api_key="lm_studio",
                 temperature=temperature,
-                tokenizer=SimpleTokenizer(
-                    characters_per_token=4,
-                    max_input_tokens=1024,
-                    max_output_tokens=1024,
-                ),
             ),
             image_generation_driver=image_generation_driver,
         )
@@ -409,7 +384,7 @@ class gtUIOpenAiStructureConfig(gtUIBaseConfig):
         if not image_generation_driver:
             image_generation_driver = OpenAiImageGenerationDriver(
                 api_key=OPENAI_API_KEY,
-                model="dalle-e-3",
+                model="dall-e-3",
             )
 
         image_query_driver = OpenAiImageQueryDriver(

--- a/nodes/tools.py
+++ b/nodes/tools.py
@@ -82,11 +82,23 @@ class gtUIWebSearch(gtUIBaseTool):
     The Griptape Web Search Tool
     """
 
-    DESCRIPTION = "Search the web using DuckDuckGo."
+    DESCRIPTION = "Search the web."
 
-    def create(self, off_prompt):
+    @classmethod
+    def INPUT_TYPES(s):
+        inputs = super().INPUT_TYPES()
+        inputs["optional"].update(
+            {
+                "driver": ("DRIVER", {"default": None}),
+            }
+        )
+        return inputs
+
+    def create(self, off_prompt, driver=None):
+        if not driver:
+            driver = DuckDuckGoWebSearchDriver()
         tool = WebSearch(
-            web_search_driver=DuckDuckGoWebSearchDriver(),
+            web_search_driver=driver,
             off_prompt=off_prompt,
         )
         return ([tool],)

--- a/nodes/tools.py
+++ b/nodes/tools.py
@@ -1,5 +1,5 @@
 import requests
-from griptape.drivers import OpenAiAudioTranscriptionDriver
+from griptape.drivers import DuckDuckGoWebSearchDriver, OpenAiAudioTranscriptionDriver
 from griptape.engines import AudioTranscriptionEngine
 from griptape.tools import (
     Calculator,
@@ -7,12 +7,12 @@ from griptape.tools import (
     FileManager,
     GriptapeCloudKnowledgeBaseClient,
     WebScraper,
+    WebSearch,
 )
 from griptape.tools.audio_transcription_client.tool import AudioTranscriptionClient
 
 from ..py.griptape_config import get_config
 from .base_tool import gtUIBaseTool
-from .duckduckgo_client import DuckDuckGoTool
 
 
 class gtUIAudioTranscriptionClient(gtUIBaseTool):
@@ -85,7 +85,8 @@ class gtUIWebSearch(gtUIBaseTool):
     DESCRIPTION = "Search the web using DuckDuckGo."
 
     def create(self, off_prompt):
-        tool = DuckDuckGoTool(
+        tool = WebSearch(
+            web_search_driver=DuckDuckGoWebSearchDriver(),
             off_prompt=off_prompt,
         )
         return ([tool],)

--- a/nodes/websearch_drivers.py
+++ b/nodes/websearch_drivers.py
@@ -1,0 +1,55 @@
+from griptape.drivers import DuckDuckGoWebSearchDriver, GoogleWebSearchDriver
+
+from ..py.griptape_config import get_config
+from .base_websearch_driver import gtUIBaseWebSearchDriver
+
+
+class gtUIDuckDuckGoWebSearchDriver(gtUIBaseWebSearchDriver):
+    DESCRIPTION = "DuckDuckGo Web Search Driver"
+
+    def create(
+        self,
+    ):
+        driver = DuckDuckGoWebSearchDriver()
+        return (driver,)
+
+
+class gtUIGoogleWebSearchDriver(gtUIBaseWebSearchDriver):
+    DESCRIPTION = "Google Web Search Driver. Requires environment variables GOOGLE_API_KEY and GOOGLE_API_SEARCH_ID."
+
+    @classmethod
+    def INPUT_TYPES(s):
+        inputs = super().INPUT_TYPES()
+        inputs["required"].update(
+            {
+                "country": ("STRING", {"default": "us"}),
+                "language": ("STRING", {"default": "en"}),
+                "results_count": ("INT", {"default": 5}),
+            }
+        )
+        return inputs
+
+    def get_api_key(self, KEY_ID):
+        # will get the API key from the environment, or return the default value
+        return get_config(key=KEY_ID, default=None)
+
+    def create(self, language="en", country="us", results_count=5):
+        GOOGLE_API_KEY = self.get_api_key("env.GOOGLE_API_KEY")
+        GOOGLE_API_SEARCH_ID = self.get_api_key("env.GOOGLE_API_SEARCH_ID")
+
+        if not GOOGLE_API_KEY:
+            raise Exception(
+                "Google API Key not found. Please set the environment variable GOOGLE_API_KEY."
+            )
+        if not GOOGLE_API_SEARCH_ID:
+            raise Exception(
+                "Google API Search ID not found. Please set the environment variable GOOGLE_API_SEARCH_ID."
+            )
+        driver = GoogleWebSearchDriver(
+            api_key=GOOGLE_API_KEY,
+            search_id=GOOGLE_API_SEARCH_ID,
+            country=country,
+            language=language,
+            results_count=results_count,
+        )
+        return (driver,)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-griptape [all] == 0.27.2
+griptape [all] == 0.28.0
 python-dotenv
-duckduckgo_search

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-griptape [all] == 0.28.0
+griptape [all] == 0.28.1
 python-dotenv

--- a/workflows/ConfigTests.json
+++ b/workflows/ConfigTests.json
@@ -1,0 +1,1394 @@
+{
+  "last_node_id": 28,
+  "last_link_id": 15,
+  "nodes": [
+    {
+      "id": 2,
+      "type": "Griptape Agent Config: Amazon Bedrock",
+      "pos": [
+        3271,
+        1345
+      ],
+      "size": {
+        "0": 380.4000244140625,
+        "1": 154
+      },
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image_generation_driver",
+          "type": "DRIVER",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONFIG",
+          "type": "CONFIG",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {},
+      "widgets_values": [
+        "anthropic.claude-3-5-sonnet-20240620-v1:0",
+        "anthropic.claude-3-5-sonnet-20240620-v1:0",
+        0.1,
+        2048,
+        "fixed"
+      ]
+    },
+    {
+      "id": 3,
+      "type": "Griptape Agent Config: Google",
+      "pos": [
+        3271,
+        1549
+      ],
+      "size": {
+        "0": 380.4000244140625,
+        "1": 130
+      },
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image_generation_driver",
+          "type": "DRIVER",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONFIG",
+          "type": "CONFIG",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {},
+      "widgets_values": [
+        "gemini-1.5-pro",
+        0.1,
+        2048,
+        "fixed"
+      ]
+    },
+    {
+      "id": 4,
+      "type": "Griptape Agent Config: Anthropic",
+      "pos": [
+        3271,
+        1740
+      ],
+      "size": {
+        "0": 380.4000244140625,
+        "1": 154
+      },
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image_generation_driver",
+          "type": "DRIVER",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONFIG",
+          "type": "CONFIG",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {},
+      "widgets_values": [
+        "claude-3-5-sonnet-20240620",
+        "claude-3-5-sonnet-20240620",
+        0.1,
+        2048,
+        "fixed"
+      ]
+    },
+    {
+      "id": 5,
+      "type": "Griptape Agent Config: Ollama",
+      "pos": [
+        3271,
+        1956
+      ],
+      "size": {
+        "0": 380.4000244140625,
+        "1": 178
+      },
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image_generation_driver",
+          "type": "DRIVER",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONFIG",
+          "type": "CONFIG",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {},
+      "widgets_values": [
+        "llava:latest",
+        "http://127.0.0.1",
+        "11434",
+        0.1,
+        2048,
+        "fixed"
+      ]
+    },
+    {
+      "id": 6,
+      "type": "Griptape Agent Config: LM Studio",
+      "pos": [
+        3271,
+        2193
+      ],
+      "size": {
+        "0": 380.4000244140625,
+        "1": 178
+      },
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image_generation_driver",
+          "type": "DRIVER",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONFIG",
+          "type": "CONFIG",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {},
+      "widgets_values": [
+        "lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF/Meta-Llama-3-8B-Instruct-Q4_K_M.gguf",
+        "http://127.0.0.1",
+        "1234",
+        0.1,
+        2048,
+        "fixed"
+      ]
+    },
+    {
+      "id": 1,
+      "type": "Griptape Agent Config: OpenAI",
+      "pos": [
+        3271,
+        1128.7327263954087
+      ],
+      "size": {
+        "0": 380.4000244140625,
+        "1": 154
+      },
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image_generation_driver",
+          "type": "DRIVER",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONFIG",
+          "type": "CONFIG",
+          "links": [
+            3
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {},
+      "widgets_values": [
+        "gpt-4o",
+        "gpt-4o",
+        0.1,
+        2048,
+        "fixed"
+      ]
+    },
+    {
+      "id": 8,
+      "type": "Griptape Display: Text",
+      "pos": [
+        4180,
+        1130
+      ],
+      "size": {
+        "0": 362.1826171875,
+        "1": 143.33529663085938
+      },
+      "flags": {},
+      "order": 20,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "INPUT",
+          "type": "STRING",
+          "link": 1,
+          "widget": {
+            "name": "INPUT"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "OUTPUT",
+          "type": "STRING",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Griptape Display: Text"
+      },
+      "widgets_values": [
+        "",
+        "I am based on OpenAI's GPT-4 model. How can I assist you today?"
+      ]
+    },
+    {
+      "id": 7,
+      "type": "Griptape Create: Agent",
+      "pos": [
+        3740,
+        1130
+      ],
+      "size": {
+        "0": 388.1346740722656,
+        "1": 156
+      },
+      "flags": {},
+      "order": 13,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "agent",
+          "type": "AGENT",
+          "link": null
+        },
+        {
+          "name": "config",
+          "type": "CONFIG",
+          "link": 3
+        },
+        {
+          "name": "tools",
+          "type": "TOOL_LIST",
+          "link": null
+        },
+        {
+          "name": "rulesets",
+          "type": "RULESET",
+          "link": null
+        },
+        {
+          "name": "input_string",
+          "type": "STRING",
+          "link": null,
+          "widget": {
+            "name": "input_string"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "OUTPUT",
+          "type": "STRING",
+          "links": [
+            1
+          ],
+          "shape": 3,
+          "slot_index": 0
+        },
+        {
+          "name": "AGENT",
+          "type": "AGENT",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Griptape Create: Agent"
+      },
+      "widgets_values": [
+        "",
+        "What modle are you?"
+      ]
+    },
+    {
+      "id": 16,
+      "type": "Griptape Create: Agent",
+      "pos": [
+        500,
+        40
+      ],
+      "size": [
+        349.58668309992004,
+        163.0926728682084
+      ],
+      "flags": {},
+      "order": 14,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "agent",
+          "type": "AGENT",
+          "link": null
+        },
+        {
+          "name": "config",
+          "type": "CONFIG",
+          "link": 10
+        },
+        {
+          "name": "tools",
+          "type": "TOOL_LIST",
+          "link": null
+        },
+        {
+          "name": "rulesets",
+          "type": "RULESET",
+          "link": null
+        },
+        {
+          "name": "input_string",
+          "type": "STRING",
+          "link": null,
+          "widget": {
+            "name": "input_string"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "OUTPUT",
+          "type": "STRING",
+          "links": [
+            4
+          ],
+          "shape": 3,
+          "slot_index": 0
+        },
+        {
+          "name": "AGENT",
+          "type": "AGENT",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Griptape Create: Agent"
+      },
+      "widgets_values": [
+        "",
+        "What model are you?"
+      ]
+    },
+    {
+      "id": 18,
+      "type": "Griptape Create: Agent",
+      "pos": [
+        500,
+        248.5472183227539
+      ],
+      "size": [
+        349.58668309992004,
+        163.0926728682084
+      ],
+      "flags": {},
+      "order": 19,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "agent",
+          "type": "AGENT",
+          "link": null
+        },
+        {
+          "name": "config",
+          "type": "CONFIG",
+          "link": 11
+        },
+        {
+          "name": "tools",
+          "type": "TOOL_LIST",
+          "link": null
+        },
+        {
+          "name": "rulesets",
+          "type": "RULESET",
+          "link": null
+        },
+        {
+          "name": "input_string",
+          "type": "STRING",
+          "link": null,
+          "widget": {
+            "name": "input_string"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "OUTPUT",
+          "type": "STRING",
+          "links": [
+            5
+          ],
+          "shape": 3,
+          "slot_index": 0
+        },
+        {
+          "name": "AGENT",
+          "type": "AGENT",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Griptape Create: Agent"
+      },
+      "widgets_values": [
+        "",
+        "What model are you?"
+      ]
+    },
+    {
+      "id": 19,
+      "type": "Griptape Display: Text",
+      "pos": [
+        930,
+        260
+      ],
+      "size": [
+        336.3139558271928,
+        148.45630923184478
+      ],
+      "flags": {},
+      "order": 26,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "INPUT",
+          "type": "STRING",
+          "link": 5,
+          "widget": {
+            "name": "INPUT"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "OUTPUT",
+          "type": "STRING",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Griptape Display: Text"
+      },
+      "widgets_values": [
+        "",
+        "I am a large language model called Titan. How may I help you?"
+      ]
+    },
+    {
+      "id": 26,
+      "type": "Griptape Create: Agent",
+      "pos": [
+        500,
+        1210
+      ],
+      "size": [
+        349.58668309992004,
+        163.0926728682084
+      ],
+      "flags": {},
+      "order": 18,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "agent",
+          "type": "AGENT",
+          "link": null
+        },
+        {
+          "name": "config",
+          "type": "CONFIG",
+          "link": 15
+        },
+        {
+          "name": "tools",
+          "type": "TOOL_LIST",
+          "link": null
+        },
+        {
+          "name": "rulesets",
+          "type": "RULESET",
+          "link": null
+        },
+        {
+          "name": "input_string",
+          "type": "STRING",
+          "link": null,
+          "widget": {
+            "name": "input_string"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "OUTPUT",
+          "type": "STRING",
+          "links": [
+            9
+          ],
+          "shape": 3,
+          "slot_index": 0
+        },
+        {
+          "name": "AGENT",
+          "type": "AGENT",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Griptape Create: Agent"
+      },
+      "widgets_values": [
+        "",
+        "What model are you?"
+      ]
+    },
+    {
+      "id": 27,
+      "type": "Griptape Display: Text",
+      "pos": [
+        930,
+        1210
+      ],
+      "size": [
+        336.3139558271928,
+        148.45630923184478
+      ],
+      "flags": {},
+      "order": 25,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "INPUT",
+          "type": "STRING",
+          "link": 9,
+          "widget": {
+            "name": "INPUT"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "OUTPUT",
+          "type": "STRING",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Griptape Display: Text"
+      },
+      "widgets_values": [
+        "",
+        "I am LLaMA, a large language model trained by a team of researcher at Meta AI."
+      ]
+    },
+    {
+      "id": 25,
+      "type": "Griptape Display: Text",
+      "pos": [
+        930,
+        960
+      ],
+      "size": [
+        336.3139558271928,
+        148.45630923184478
+      ],
+      "flags": {},
+      "order": 24,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "INPUT",
+          "type": "STRING",
+          "link": 8,
+          "widget": {
+            "name": "INPUT"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "OUTPUT",
+          "type": "STRING",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Griptape Display: Text"
+      },
+      "widgets_values": [
+        "",
+        " I am a language model, specifically a transformer-based model. The exact architecture and version of the model may vary depending on the specific implementation or training data used. "
+      ]
+    },
+    {
+      "id": 24,
+      "type": "Griptape Create: Agent",
+      "pos": [
+        500,
+        960
+      ],
+      "size": [
+        349.58668309992004,
+        163.0926728682084
+      ],
+      "flags": {},
+      "order": 17,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "agent",
+          "type": "AGENT",
+          "link": null
+        },
+        {
+          "name": "config",
+          "type": "CONFIG",
+          "link": 14
+        },
+        {
+          "name": "tools",
+          "type": "TOOL_LIST",
+          "link": null
+        },
+        {
+          "name": "rulesets",
+          "type": "RULESET",
+          "link": null
+        },
+        {
+          "name": "input_string",
+          "type": "STRING",
+          "link": null,
+          "widget": {
+            "name": "input_string"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "OUTPUT",
+          "type": "STRING",
+          "links": [
+            8
+          ],
+          "shape": 3,
+          "slot_index": 0
+        },
+        {
+          "name": "AGENT",
+          "type": "AGENT",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Griptape Create: Agent"
+      },
+      "widgets_values": [
+        "",
+        "What model are you?"
+      ]
+    },
+    {
+      "id": 22,
+      "type": "Griptape Create: Agent",
+      "pos": [
+        500,
+        730
+      ],
+      "size": [
+        349.58668309992004,
+        163.0926728682084
+      ],
+      "flags": {},
+      "order": 16,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "agent",
+          "type": "AGENT",
+          "link": null
+        },
+        {
+          "name": "config",
+          "type": "CONFIG",
+          "link": 13
+        },
+        {
+          "name": "tools",
+          "type": "TOOL_LIST",
+          "link": null
+        },
+        {
+          "name": "rulesets",
+          "type": "RULESET",
+          "link": null
+        },
+        {
+          "name": "input_string",
+          "type": "STRING",
+          "link": null,
+          "widget": {
+            "name": "input_string"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "OUTPUT",
+          "type": "STRING",
+          "links": [
+            7
+          ],
+          "shape": 3,
+          "slot_index": 0
+        },
+        {
+          "name": "AGENT",
+          "type": "AGENT",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Griptape Create: Agent"
+      },
+      "widgets_values": [
+        "",
+        "What model are you?"
+      ]
+    },
+    {
+      "id": 23,
+      "type": "Griptape Display: Text",
+      "pos": [
+        930,
+        730
+      ],
+      "size": [
+        336.3139558271928,
+        148.45630923184478
+      ],
+      "flags": {},
+      "order": 23,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "INPUT",
+          "type": "STRING",
+          "link": 7,
+          "widget": {
+            "name": "INPUT"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "OUTPUT",
+          "type": "STRING",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Griptape Display: Text"
+      },
+      "widgets_values": [
+        "",
+        "I am an AI assistant created by Anthropic to be helpful, harmless, and honest. I don't have a specific model name or number."
+      ]
+    },
+    {
+      "id": 20,
+      "type": "Griptape Create: Agent",
+      "pos": [
+        500,
+        500
+      ],
+      "size": [
+        349.58668309992004,
+        163.0926728682084
+      ],
+      "flags": {},
+      "order": 15,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "agent",
+          "type": "AGENT",
+          "link": null
+        },
+        {
+          "name": "config",
+          "type": "CONFIG",
+          "link": 12
+        },
+        {
+          "name": "tools",
+          "type": "TOOL_LIST",
+          "link": null
+        },
+        {
+          "name": "rulesets",
+          "type": "RULESET",
+          "link": null
+        },
+        {
+          "name": "input_string",
+          "type": "STRING",
+          "link": null,
+          "widget": {
+            "name": "input_string"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "OUTPUT",
+          "type": "STRING",
+          "links": [
+            6
+          ],
+          "shape": 3,
+          "slot_index": 0
+        },
+        {
+          "name": "AGENT",
+          "type": "AGENT",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Griptape Create: Agent"
+      },
+      "widgets_values": [
+        "",
+        "What model are you?"
+      ]
+    },
+    {
+      "id": 21,
+      "type": "Griptape Display: Text",
+      "pos": [
+        930,
+        500
+      ],
+      "size": [
+        336.3139558271928,
+        148.45630923184478
+      ],
+      "flags": {},
+      "order": 22,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "INPUT",
+          "type": "STRING",
+          "link": 6,
+          "widget": {
+            "name": "INPUT"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "OUTPUT",
+          "type": "STRING",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Griptape Display: Text"
+      },
+      "widgets_values": [
+        "",
+        "I am a large language model, trained by Google. \n\nIt's important to note that I am not a person, but rather a complex algorithm designed to process and generate text. I don't have feelings, experiences, or a physical body. My purpose is to provide helpful and informative responses based on the vast dataset I was trained on. \n\nIf you have any other questions, feel free to ask! \n"
+      ]
+    },
+    {
+      "id": 17,
+      "type": "Griptape Display: Text",
+      "pos": [
+        930,
+        50
+      ],
+      "size": [
+        336.3139558271928,
+        148.45630923184478
+      ],
+      "flags": {},
+      "order": 21,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "INPUT",
+          "type": "STRING",
+          "link": 4,
+          "widget": {
+            "name": "INPUT"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "OUTPUT",
+          "type": "STRING",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Griptape Display: Text"
+      },
+      "widgets_values": [
+        "",
+        "I am based on OpenAI's GPT-4 model. How can I assist you today?"
+      ]
+    },
+    {
+      "id": 10,
+      "type": "Griptape Agent Config: OpenAI",
+      "pos": [
+        10,
+        47
+      ],
+      "size": {
+        "0": 380.4000244140625,
+        "1": 154
+      },
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image_generation_driver",
+          "type": "DRIVER",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONFIG",
+          "type": "CONFIG",
+          "links": [
+            10
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {},
+      "widgets_values": [
+        "gpt-4o",
+        "gpt-4o",
+        0.1,
+        2048,
+        "fixed"
+      ]
+    },
+    {
+      "id": 12,
+      "type": "Griptape Agent Config: Google",
+      "pos": [
+        10,
+        500
+      ],
+      "size": {
+        "0": 380.4000244140625,
+        "1": 130
+      },
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image_generation_driver",
+          "type": "DRIVER",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONFIG",
+          "type": "CONFIG",
+          "links": [
+            12
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {},
+      "widgets_values": [
+        "gemini-1.5-pro",
+        0.1,
+        2048,
+        "fixed"
+      ]
+    },
+    {
+      "id": 13,
+      "type": "Griptape Agent Config: Anthropic",
+      "pos": [
+        10,
+        730
+      ],
+      "size": {
+        "0": 380.4000244140625,
+        "1": 154
+      },
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image_generation_driver",
+          "type": "DRIVER",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONFIG",
+          "type": "CONFIG",
+          "links": [
+            13
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {},
+      "widgets_values": [
+        "claude-3-5-sonnet-20240620",
+        "claude-3-5-sonnet-20240620",
+        0.1,
+        2048,
+        "fixed"
+      ]
+    },
+    {
+      "id": 14,
+      "type": "Griptape Agent Config: Ollama",
+      "pos": [
+        10,
+        960
+      ],
+      "size": {
+        "0": 380.4000244140625,
+        "1": 178
+      },
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image_generation_driver",
+          "type": "DRIVER",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONFIG",
+          "type": "CONFIG",
+          "links": [
+            14
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {},
+      "widgets_values": [
+        "llava:latest",
+        "http://127.0.0.1",
+        "11434",
+        0.1,
+        2048,
+        "fixed"
+      ]
+    },
+    {
+      "id": 28,
+      "type": "Terminal Log //CM",
+      "pos": [
+        41,
+        1462
+      ],
+      "size": [
+        1214.4394958812504,
+        584.5862170164069
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "properties": {
+        "text": ""
+      },
+      "color": "#222222",
+      "bgcolor": "#000000"
+    },
+    {
+      "id": 15,
+      "type": "Griptape Agent Config: LM Studio",
+      "pos": [
+        10,
+        1210
+      ],
+      "size": {
+        "0": 380.4000244140625,
+        "1": 178
+      },
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image_generation_driver",
+          "type": "DRIVER",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONFIG",
+          "type": "CONFIG",
+          "links": [
+            15
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {},
+      "widgets_values": [
+        "lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF/Meta-Llama-3-8B-Instruct-Q4_K_M.gguf",
+        "http://127.0.0.1",
+        "1234",
+        0.1,
+        2048,
+        "fixed"
+      ]
+    },
+    {
+      "id": 11,
+      "type": "Griptape Agent Config: Amazon Bedrock",
+      "pos": [
+        10,
+        265
+      ],
+      "size": {
+        "0": 380.4000244140625,
+        "1": 154
+      },
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image_generation_driver",
+          "type": "DRIVER",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONFIG",
+          "type": "CONFIG",
+          "links": [
+            11
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {},
+      "widgets_values": [
+        "anthropic.claude-3-5-sonnet-20240620-v1:0",
+        "anthropic.claude-3-5-sonnet-20240620-v1:0",
+        0.1,
+        2048,
+        "fixed"
+      ]
+    }
+  ],
+  "links": [
+    [
+      1,
+      7,
+      0,
+      8,
+      0,
+      "STRING"
+    ],
+    [
+      3,
+      1,
+      0,
+      7,
+      1,
+      "CONFIG"
+    ],
+    [
+      4,
+      16,
+      0,
+      17,
+      0,
+      "STRING"
+    ],
+    [
+      5,
+      18,
+      0,
+      19,
+      0,
+      "STRING"
+    ],
+    [
+      6,
+      20,
+      0,
+      21,
+      0,
+      "STRING"
+    ],
+    [
+      7,
+      22,
+      0,
+      23,
+      0,
+      "STRING"
+    ],
+    [
+      8,
+      24,
+      0,
+      25,
+      0,
+      "STRING"
+    ],
+    [
+      9,
+      26,
+      0,
+      27,
+      0,
+      "STRING"
+    ],
+    [
+      10,
+      10,
+      0,
+      16,
+      1,
+      "CONFIG"
+    ],
+    [
+      11,
+      11,
+      0,
+      18,
+      1,
+      "CONFIG"
+    ],
+    [
+      12,
+      12,
+      0,
+      20,
+      1,
+      "CONFIG"
+    ],
+    [
+      13,
+      13,
+      0,
+      22,
+      1,
+      "CONFIG"
+    ],
+    [
+      14,
+      14,
+      0,
+      24,
+      1,
+      "CONFIG"
+    ],
+    [
+      15,
+      15,
+      0,
+      26,
+      1,
+      "CONFIG"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 1,
+      "offset": {
+        "0": 370.816162109375,
+        "1": -84.1327896118164
+      }
+    }
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
* Updated to work with Griptape v0.28.1
* Image Description node now can handle multiple images at once, and works with Open Source llava.
* Fixed tool, config, ruleset, memory bugs for creating agents based on update to v0.28.0
* **New Nodes** Added WebSearch Drivers: DuckDuckGo and Google Search. To use Google Search, you must have two API keys - GOOGLE_API_KEY and GOOGLE_API_SEARCH_ID. 
