### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ You can previous and download more examples [here](examples/README.md).
 
 ## Recent Changelog
 
+### Sept 12, 2024
+* Hotfix for `Griptape Run: Tool Task` node. It now properly handles the output of the tool being a list.
+
 ### Sept 11, 2024
 * Added `top_p` and `top_k` to Anthropic and Google Prompt Drivers
 * Fixed automatic display node text resizing

--- a/js/versions.js
+++ b/js/versions.js
@@ -1,11 +1,18 @@
 export const versions = {
-  "version": "0.31.0c",
-  "releaseDate": "2024-09-10",
+  "version": "0.31.0d",
+  "releaseDate": "2024-09-12",
   "name": "ComfyUI-Griptape",
   "description": "Griptape integration for ComfyUI",
   "author": "Jason Schleifer",
   "repository": "https://github.com/griptape-ai/ComfyUI-Griptape",
   "changelog": [
+    {
+      "version": "0.31.0d",
+      "date": "2024-09-12",
+      "changes": [
+        "Fixed Griptape Run: Tool Task node",
+      ]
+    }, 
     {
       "version": "0.31.0c",
       "date": "2024-09-11",

--- a/nodes/tasks/gtUIToolTask.py
+++ b/nodes/tasks/gtUIToolTask.py
@@ -46,5 +46,8 @@ class gtUIToolTask(gtUIBaseTask):
 
         agent.add_task(ToolTask(tool=tool[0]))
         result = agent.run(prompt_text)
-
-        return (result.output_task.output.value, agent)
+        if isinstance(result.output_task.output.value, list):
+            output = result.output_task.output.value[0]
+        else:
+            output = result.output_task.output.value
+        return (output, agent)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "comfyui-griptape"
-version = "1.0.3"
+version = "1.0.4"
 description = "Griptape LLM(Large Language Model) Nodes for ComfyUI."
 authors = ["Jason Schleifer <jason.schleifer@gmail.com>"]
 readme = "README.md"
@@ -26,7 +26,7 @@ priority = "explicit"
 [project]
 name = "comfyui-griptape"
 description = "Griptape LLM(Large Language Model) Nodes for ComfyUI."
-version = "1.0.3"
+version = "1.0.4"
 license = {file = "LICENSE"}
 dependencies = ["griptape[drivers-prompt-cohere,drivers-prompt-anthropic,drivers-prompt-huggingface-hub,drivers-prompt-amazon-bedrock,drivers-prompt-amazon-sagemaker,drivers-prompt-google,drivers-prompt-ollama,drivers-embedding-amazon-bedrock,drivers-embedding-amazon-sagemaker,drivers-embedding-huggingface,drivers-embedding-voyageai,drivers-embedding-google,drivers-embedding-cohere,drivers-text-to-speech-elevenlabs,drivers-vector-pinecone,drivers-vector-marqo,drivers-vector-mongodb,drivers-vector-redis,drivers-vector-opensearch,drivers-vector-pgvector,drivers-vector-qdrant,drivers-web-scraper-trafilatura,drivers-web-scraper-markdownify,drivers-web-search-duckduckgo,loaders-dataframe,loaders-pdf,loaders-image,loaders-email,loaders-audio]==0.31.0", "python-dotenv"]
 


### PR DESCRIPTION
* Hotfix for `Griptape Run: Tool Task` node. It now properly handles the output of the tool being a list.
