### PR TITLE
212-update-to-griptape-110

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed 
 ### Security  -->
 
+## [2.1.00] - 2025-03-01
+### Changed
+- Updated Griptape Framework to 1.1.0
+- Updated Poetry to version 1.8.5
+- Set default `max_attempts_on_fail` for prompt drivers to 2 instead of 10.
+### Removed
+- `Griptape Code: Run Python` node was echoing code to console.log. This has been removed.
+
 ## [2.0.17] - 2025-02-01
-## Fixed
+### Fixed
 - Updated text when running Python code is not enabled.
-## Removed
+### Removed
 - in `gtUICodeExecutionTask.py` removed unused `unique_id` variable.
 
 ## [2.0.16] - 2025-02-01

--- a/js/CodeExecutionNode.js
+++ b/js/CodeExecutionNode.js
@@ -49,7 +49,6 @@ function make_code_execution_templates_submenu(value, options, e, menu, node) {
         callback: function (v) { 
           const code_widget = node.widgets.find(w => w.name === 'code');
           code_widget.value = code_execution_templates[v];
-          console.log(v, code_widget.value);
             // do something with v (=="option x")
         }, 
         parentMenu: menu, 

--- a/nodes/config/deprecated/gtUIAmazonBedrockStructureConfig.py
+++ b/nodes/config/deprecated/gtUIAmazonBedrockStructureConfig.py
@@ -71,7 +71,7 @@ class gtUIAmazonBedrockStructureConfig(gtUIBaseConfig):
 
         prompt_model = kwargs.get("prompt_model", amazonBedrockPromptModels[0])
         temperature = kwargs.get("temperature", 0.7)
-        max_attempts = kwargs.get("max_attempts_on_fail", 10)
+        max_attempts = kwargs.get("max_attempts_on_fail", 2)
         use_native_tools = kwargs.get("use_native_tools", False)
         max_tokens = kwargs.get("max_tokens", None)
         params["model"] = prompt_model

--- a/nodes/config/deprecated/gtUIAnthropicStructureConfig.py
+++ b/nodes/config/deprecated/gtUIAnthropicStructureConfig.py
@@ -54,7 +54,7 @@ class gtUIAnthropicStructureConfig(gtUIBaseConfig):
 
         params["model"] = kwargs.get("prompt_model", anthropicPromptModels[0])
         params["temperature"] = kwargs.get("temperature", 0.7)
-        params["max_attempts"] = kwargs.get("max_attempts_on_fail", 10)
+        params["max_attempts"] = kwargs.get("max_attempts_on_fail", 2)
         params["use_native_tools"] = kwargs.get("use_native_tools", True)
         params["api_key"] = self.getenv(kwargs.get("api_key_env_var", DEFAULT_API_KEY))
 

--- a/nodes/config/deprecated/gtUIAzureOpenAiStructureConfig.py
+++ b/nodes/config/deprecated/gtUIAzureOpenAiStructureConfig.py
@@ -58,7 +58,7 @@ class gtUIAzureOpenAiStructureConfig(gtUIBaseConfig):
         params["model"] = kwargs.get("prompt_model", "gpt-4o")
         params["temperature"] = kwargs.get("temperature", 0.7)
         params["seed"] = kwargs.get("seed", 12341)
-        params["max_attempts"] = kwargs.get("max_attempts_on_fail", 10)
+        params["max_attempts"] = kwargs.get("max_attempts_on_fail", 2)
         params["azure_deployment"] = kwargs.get("prompt_model_deployment_name", "gpt4o")
         params["use_native_tools"] = kwargs.get("use_native_tools", False)
         params["stream"] = kwargs.get("stream", False)

--- a/nodes/config/deprecated/gtUIGoogleStructureConfig.py
+++ b/nodes/config/deprecated/gtUIGoogleStructureConfig.py
@@ -54,7 +54,7 @@ class gtUIGoogleStructureConfig(gtUIBaseConfig):
         params = {}
         temperature = kwargs.get("temperature", 0.7)
         prompt_model = kwargs.get("prompt_model", google_models[0])
-        max_attempts = kwargs.get("max_attempts_on_fail", 10)
+        max_attempts = kwargs.get("max_attempts_on_fail", 2)
         api_key = self.getenv(kwargs.get("api_key_env_var", DEFAULT_API_KEY))
         use_native_tools = kwargs.get("use_native_tools", False)
         max_tokens = kwargs.get("max_tokens", -1)

--- a/nodes/config/deprecated/gtUIHuggingFaceStructureConfig.py
+++ b/nodes/config/deprecated/gtUIHuggingFaceStructureConfig.py
@@ -42,7 +42,7 @@ class gtUIHuggingFaceStructureConfig(gtUIBaseConfig):
         prompt_model = kwargs.get("prompt_model", None)
         temperature = kwargs.get("temperature", 0.7)
         stream = kwargs.get("stream", False)
-        max_attempts = kwargs.get("max_attempts_on_fail", 10)
+        max_attempts = kwargs.get("max_attempts_on_fail", 2)
         use_native_tools = kwargs.get("use_native_tools", False)
         api_token = self.getenv(kwargs.get("api_token_env_var", DEFAULT_API_KEY))
         configs = {}

--- a/nodes/config/deprecated/gtUILMStudioStructureConfig.py
+++ b/nodes/config/deprecated/gtUILMStudioStructureConfig.py
@@ -56,7 +56,7 @@ class gtUILMStudioStructureConfig(gtUIBaseConfig):
         base_url = kwargs.get("base_url", lmstudio_base_url)
         params["base_url"] = f"{base_url}:{port}/v1"
         params["temperature"] = kwargs.get("temperature", 0.7)
-        params["max_attempts"] = kwargs.get("max_attempts_on_fail", 10)
+        params["max_attempts"] = kwargs.get("max_attempts_on_fail", 2)
         params["stream"] = kwargs.get("stream", False)
         params["seed"] = kwargs.get("seed", 12341)
         params["use_native_tools"] = kwargs.get("use_native_tools", False)

--- a/nodes/config/deprecated/gtUIOllamaStructureConfig.py
+++ b/nodes/config/deprecated/gtUIOllamaStructureConfig.py
@@ -42,7 +42,7 @@ class gtUIOllamaStructureConfig(gtUIBaseConfig):
         params["host"] = f"{base_url}:{port}"
         params["stream"] = kwargs.get("stream", False)
         params["use_native_tools"] = kwargs.get("use_native_tools", False)
-        params["max_attempts"] = kwargs.get("max_attempts_on_fail", 10)
+        params["max_attempts"] = kwargs.get("max_attempts_on_fail", 2)
         max_tokens = kwargs.get("max_tokens", -1)
         if max_tokens > 0:
             params["max_tokens"] = max_tokens

--- a/nodes/config/deprecated/gtUIOpenAiCompatibleConfig.py
+++ b/nodes/config/deprecated/gtUIOpenAiCompatibleConfig.py
@@ -46,7 +46,7 @@ class gtUIOpenAiCompatibleConfig(gtUIBaseConfig):
 
         params["model"] = kwargs.get("prompt_model", None)
         params["base_url"] = kwargs.get("base_url", None)
-        params["max_attempts"] = kwargs.get("max_attempts_on_fail", 10)
+        params["max_attempts"] = kwargs.get("max_attempts_on_fail", 2)
         params["stream"] = kwargs.get("stream", False)
         params["use_native_tools"] = kwargs.get("use_native_tools", False)
         api_key_env_var = kwargs.get("api_key_env_var", DEFAULT_API_KEY)

--- a/nodes/config/deprecated/gtUIOpenAiStructureConfig.py
+++ b/nodes/config/deprecated/gtUIOpenAiStructureConfig.py
@@ -48,7 +48,7 @@ class gtUIOpenAiStructureConfig(gtUIBaseConfig):
         params["model"] = kwargs.get("prompt_model", default_prompt_model)
         params["temperature"] = kwargs.get("temperature", 0.7)
         params["seed"] = kwargs.get("seed", 12341)
-        params["max_attempts"] = kwargs.get("max_attempts_on_fail", 10)
+        params["max_attempts"] = kwargs.get("max_attempts_on_fail", 2)
         params["api_key"] = self.getenv(kwargs.get("api_key_env_var", DEFAULT_API_KEY))
         params["use_native_tools"] = kwargs.get("use_native_tools", False)
         max_tokens = kwargs.get("max_tokens", -1)

--- a/nodes/config/gtUIBaseConfig.py
+++ b/nodes/config/gtUIBaseConfig.py
@@ -47,7 +47,7 @@ class gtUIBaseConfig:
                 "seed": ("INT", {"default": 10342349342}),
                 "max_attempts_on_fail": (
                     "INT",
-                    {"default": 10, "min": 1, "max": 100},
+                    {"default": 2, "min": 1, "max": 100},
                 ),
                 # "stream": ([True, False], {"default": False}),
                 "env": ("ENV", {"default": None}),

--- a/nodes/drivers/gtUIBasePromptDriver.py
+++ b/nodes/drivers/gtUIBasePromptDriver.py
@@ -16,7 +16,7 @@ class gtUIBasePromptDriver(gtUIBaseDriver):
                 "max_attempts_on_fail": (
                     "INT",
                     {
-                        "default": 10,
+                        "default": 2,
                         "min": 1,
                         "max": 100,
                         "tooltip": "Maximum attempts on failure",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "comfyui-griptape"
-version = "2.0.17"
+version = "2.0.18"
 description = "Griptape LLM(Large Language Model) Nodes for ComfyUI."
 authors = ["Jason Schleifer <jason.schleifer@gmail.com>"]
 readme = "README.md"
@@ -9,9 +9,9 @@ readme = "README.md"
 [project]
 name = "comfyui-griptape"
 description = "Griptape LLM(Large Language Model) Nodes for ComfyUI."
-version = "2.0.17" 
+version = "2.0.18" 
 license = {file = "LICENSE"}
-dependencies = ["griptape[all]==^1.0.2", "python-dotenv", "poetry==1.8.4", "griptape-black-forest @ git+https://github.com/griptape-ai/griptape-black-forest.git"]
+dependencies = ["griptape[all]==^1.1.0", "python-dotenv", "poetry==1.8.5", "griptape-black-forest @ git+https://github.com/griptape-ai/griptape-black-forest.git"]
 
 [project.urls]
 Repository = "https://github.com/griptape-ai/ComfyUI-Griptape"
@@ -20,9 +20,8 @@ Repository = "https://github.com/griptape-ai/ComfyUI-Griptape"
 [tool.poetry.dependencies]
 python = "^3.11"
 python-dotenv = "^1.0.1"
-griptape = { version = "^1.0.2", extras = ["all"]}
+griptape = { version = "^1.1.0", extras = ["all"]}
 griptape-black-forest = {git = "https://github.com/griptape-ai/griptape-black-forest.git"}
-
 
 [tool.poetry.group.dev]
 optional = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-griptape[all]==1.0.2
+griptape[all]==1.1.0
 python-dotenv
-poetry==1.8.4
+poetry==1.8.5
 git+https://github.com/griptape-ai/griptape-black-forest.git


### PR DESCRIPTION
## [2.1.00] - 2025-03-01
### Changed
- Updated Griptape Framework to 1.1.0
- Updated Poetry to version 1.8.5
- Set default `max_attempts_on_fail` for prompt drivers to 2 instead of 10.
### Removed
- `Griptape Code: Run Python` node was echoing code to console.log. This has been removed.
