### PR TITLE
Update/add_default_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed 
 ### Security   -->
 
+## [2.1.09] - 2025-10-01
+### Added
+- Added `Ollama base_url` setting to Griptape Settings to allow you to specify a default base_url instead of always using `http://127.0.0.1`. If you change this setting, you must refresh your browser, and then re-create your existing `Ollama` nodes to get it to apply.
+
+### Changed
+- Created `settings.js` to make it easier to work with Griptape Settings for comfyUI.
+- Version bump
+
 ## [2.1.08] - 2025-09-01
 ### Fixed
 - incorrectly identified attrs and openai library versions in pyproject.

--- a/js/gtUINodes.js
+++ b/js/gtUINodes.js
@@ -15,7 +15,7 @@ import { setupMenuSeparator } from "./gtUIMenuSeparator.js";
 import { keys_organized } from "./griptape_api_keys.js";
 import { setupVisibilityToggles } from "./NodesWithVisibilityToggles.js";
 import { setupCodeExecutionNode } from "./CodeExecutionNode.js";  
-
+import { createSettings } from "./settings.js";
 const  createUrlCallback  = function(url) {
   return function() {
       window.open(url, "_blank"); // Opens the provided URL in a new tab
@@ -49,47 +49,48 @@ app.registerExtension({
     }
     api.addEventListener("comfy.gtUI.runagent", messageHandler);
 
+    createSettings(app);
     // Create the settings
-    app.ui.settings.addSetting({
-      id: `Griptape.default_config`,
-      category: ["Griptape", "!Griptape", "default_config"],
-      name: "default_config",
-      type: "dict",
-      defaultValue: "",
-      tooltip: "To set this, use the Griptape: Set Default Agent node.",
-    });
-    app.ui.settings.addSetting({
-      id: `Griptape.allow_code_execution_dangerous`,
-      category: ["Griptape", "!Griptape", "code_execution_dangerous"],
-      name: "Enable Insecure Griptape Code: Run Python [DANGER]",
-      type: "boolean",
-      tooltip: "When enabled, the Griptape Code: Run Python node will not check for dangerous code.\n\n[WARNING] This setting is dangerous and should only be enabled if you know what you are doing.",
-      defaultValue: false,
-      onChange: (newVal, oldVal) => { if (newVal == true) { console.warn("Griptape Code: Dangerous Code Execution enabled: ", newVal)} },
-    });
-    app.ui.settings.addSetting({
-      id: `Griptape.allow_code_execution`,
-      category: ["Griptape", "!Griptape", "code_execution"],
-      name: "Enable Griptape Code: Run Python Nodes",
-      type: "boolean",
-      tooltip: "When enabled, the `Griptape Code: Run Python` node will be available for use.",
-      defaultValue: false,
-      // onChange: (newVal, oldVal) => { console.log("Setting got changed!", newVal) },
-    });
-    Object.entries(keys_organized).forEach(([category, keys]) => {
-      keys.forEach((key) => {
-        app.ui.settings.addSetting({
-          id: `Griptape.${key}`,
-          category: ["Griptape", category, key],
-          name: key,
-          type: "text",
-          defaultValue: "",
-          /* To listen for changes, add an onChange parameter
-        onChange: (newVal, oldVal) => { console.log("Setting got changed!") },
-        */
-        });
-      });
-    });
+    // app.ui.settings.addSetting({
+    //   id: `Griptape.default_config`,
+    //   category: ["Griptape", "!Griptape", "default_config"],
+    //   name: "default_config",
+    //   type: "dict",
+    //   defaultValue: "",
+    //   tooltip: "To set this, use the Griptape: Set Default Agent node.",
+    // });
+    // app.ui.settings.addSetting({
+    //   id: `Griptape.allow_code_execution_dangerous`,
+    //   category: ["Griptape", "!Griptape", "code_execution_dangerous"],
+    //   name: "Enable Insecure Griptape Code: Run Python [DANGER]",
+    //   type: "boolean",
+    //   tooltip: "When enabled, the Griptape Code: Run Python node will not check for dangerous code.\n\n[WARNING] This setting is dangerous and should only be enabled if you know what you are doing.",
+    //   defaultValue: false,
+    //   onChange: (newVal, oldVal) => { if (newVal == true) { console.warn("Griptape Code: Dangerous Code Execution enabled: ", newVal)} },
+    // });
+    // app.ui.settings.addSetting({
+    //   id: `Griptape.allow_code_execution`,
+    //   category: ["Griptape", "!Griptape", "code_execution"],
+    //   name: "Enable Griptape Code: Run Python Nodes",
+    //   type: "boolean",
+    //   tooltip: "When enabled, the `Griptape Code: Run Python` node will be available for use.",
+    //   defaultValue: false,
+    //   // onChange: (newVal, oldVal) => { console.log("Setting got changed!", newVal) },
+    // });
+    // Object.entries(keys_organized).forEach(([category, keys]) => {
+    //   keys.forEach((key) => {
+    //     app.ui.settings.addSetting({
+    //       id: `Griptape.${key}`,
+    //       category: ["Griptape", category, key],
+    //       name: key,
+    //       type: "text",
+    //       defaultValue: "",
+    //       /* To listen for changes, add an onChange parameter
+    //     onChange: (newVal, oldVal) => { console.log("Setting got changed!") },
+    //     */
+    //     });
+    //   });
+    // });
   },
 
   init() {},

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,0 +1,54 @@
+import { keys_organized } from "./griptape_api_keys.js";
+
+export function createSettings(app) {
+    // Create the settings
+    app.ui.settings.addSetting({
+        id: `Griptape.default_config`,
+        category: ["Griptape", "!Griptape", "default_config"],
+        name: "default_config",
+        type: "dict",
+        defaultValue: "",
+        tooltip: "To set this, use the Griptape: Set Default Agent node.",
+        });
+    app.ui.settings.addSetting({
+        id: `Griptape.ollama_default_url`,
+        category: ["Griptape", "Ollama", "ollama_default_url"],
+        name: "default_url",
+        type: "text",
+        defaultValue: "http://127.0.0.1"
+    });
+    app.ui.settings.addSetting({
+        id: `Griptape.allow_code_execution_dangerous`,
+        category: ["Griptape", "!Griptape", "code_execution_dangerous"],
+        name: "Enable Insecure Griptape Code: Run Python [DANGER]",
+        type: "boolean",
+        tooltip: "When enabled, the Griptape Code: Run Python node will not check for dangerous code.\n\n[WARNING] This setting is dangerous and should only be enabled if you know what you are doing.",
+        defaultValue: false,
+        onChange: (newVal, oldVal) => { if (newVal == true) { console.warn("Griptape Code: Dangerous Code Execution enabled: ", newVal)} },
+        });
+    app.ui.settings.addSetting({
+        id: `Griptape.allow_code_execution`,
+        category: ["Griptape", "!Griptape", "code_execution"],
+        name: "Enable Griptape Code: Run Python Nodes",
+        type: "boolean",
+        tooltip: "When enabled, the `Griptape Code: Run Python` node will be available for use.",
+        defaultValue: false,
+        // onChange: (newVal, oldVal) => { console.log("Setting got changed!", newVal) },
+        });
+
+    Object.entries(keys_organized).forEach(([category, keys]) => {
+      keys.forEach((key) => {
+        app.ui.settings.addSetting({
+          id: `Griptape.${key}`,
+          category: ["Griptape", category, key],
+          name: key,
+          type: "text",
+          defaultValue: "",
+          /* To listen for changes, add an onChange parameter
+        onChange: (newVal, oldVal) => { console.log("Setting got changed!") },
+        */
+        });
+      });
+    });
+
+    }

--- a/nodes/drivers/gtUIOllamaEmbeddingDriver.py
+++ b/nodes/drivers/gtUIOllamaEmbeddingDriver.py
@@ -1,16 +1,10 @@
 from griptape.drivers import DummyEmbeddingDriver, OllamaEmbeddingDriver
 
+from ...py.griptape_settings import GriptapeSettings
 from .gtUIBaseEmbeddingDriver import gtUIBaseEmbeddingDriver
 
 default_port = "11434"
 default_base_url = "http://127.0.0.1"
-
-# models = get_available_models()
-# DEFAULT_MODEL = ""
-# for model in models:
-#     if "embed" in model.lower():
-#         DEFAULT_MODEL = model
-#         break
 
 
 class gtUIOllamaEmbeddingDriver(gtUIBaseEmbeddingDriver):
@@ -23,7 +17,7 @@ class gtUIOllamaEmbeddingDriver(gtUIBaseEmbeddingDriver):
                 "base_url": (
                     "STRING",
                     {
-                        "default": default_base_url,
+                        "default": cls.get_default_url(),
                         "tooltip": "The base URL of the Ollama server",
                     },
                 ),
@@ -68,11 +62,20 @@ class gtUIOllamaEmbeddingDriver(gtUIBaseEmbeddingDriver):
 
         return embedding_model in ["nomic-embed-text", "nomic-embed-text-v1.5"]
 
+    @classmethod
+    def get_default_url(cls):
+        settings = GriptapeSettings()
+        default_url = settings.get_settings_key("ollama_default_url")
+        return default_url
+
     FUNCTION = "create"
 
     def build_params(self, **kwargs):
         model = kwargs.get("embedding_model", None)
-        base_url = kwargs.get("base_url", default_base_url)
+        base_url = kwargs.get(
+            "base_url",
+            self.get_default_url(),
+        )
         port = kwargs.get("port", default_port)
 
         params = {}

--- a/nodes/drivers/gtUIOllamaPromptDriver.py
+++ b/nodes/drivers/gtUIOllamaPromptDriver.py
@@ -1,17 +1,20 @@
 from griptape.drivers import OllamaPromptDriver
+from rich import print
 
+from ...py.griptape_settings import GriptapeSettings
 from .gtUIBasePromptDriver import gtUIBasePromptDriver
 
 default_port = "11434"
 default_base_url = "http://127.0.0.1"
 
-# models = get_available_models()
-# DEFAULT_MODEL = ""
-# if len(models) > 0:
-#     DEFAULT_MODEL = models[0]
-
 
 class gtUIOllamaPromptDriver(gtUIBasePromptDriver):
+    @classmethod
+    def get_default_url(cls):
+        settings = GriptapeSettings()
+        default_url = settings.get_settings_key("ollama_default_url")
+        return default_url
+
     @classmethod
     def INPUT_TYPES(cls):
         inputs = super().INPUT_TYPES()
@@ -29,7 +32,7 @@ class gtUIOllamaPromptDriver(gtUIBasePromptDriver):
                 "base_url": (
                     "STRING",
                     {
-                        "default": default_base_url,
+                        "default": cls.get_default_url(),
                         "tooltip": "The base URL of the Ollama server",
                     },
                 ),
@@ -72,7 +75,7 @@ class gtUIOllamaPromptDriver(gtUIBasePromptDriver):
 
     def build_params(self, **kwargs):
         model = kwargs.get("model", None)
-        base_url = kwargs.get("base_url", default_base_url)
+        base_url = kwargs.get("base_url", self.get_default_url())
         port = kwargs.get("port", default_port)
         temperature = kwargs.get("temperature", None)
         max_attempts = kwargs.get("max_attempts_on_fail", None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "comfyui-griptape"
-version = "2.1.08"
+version = "2.1.09"
 description = "Griptape LLM(Large Language Model) Nodes for ComfyUI."
 authors = ["Jason Schleifer <jason.schleifer@gmail.com>"]
 readme = "README.md"
@@ -9,7 +9,7 @@ readme = "README.md"
 [project]
 name = "comfyui-griptape"
 description = "Griptape LLM(Large Language Model) Nodes for ComfyUI."
-version = "2.1.08" 
+version = "2.1.09" 
 license = {file = "LICENSE"}
 dependencies = ["attrs>=24.3.0,<25.0.0", "openai>=1.58.1,<2.0.0", "griptape[all]>=1.1.0", "python-dotenv", "poetry==1.8.5", "griptape-black-forest @ git+https://github.com/griptape-ai/griptape-black-forest.git"]
 


### PR DESCRIPTION
### Added
- Added `Ollama base_url` setting to Griptape Settings to allow you to specify a default base_url instead of always using `http://127.0.0.1`. If you change this setting, you must refresh your browser, and then re-create your existing `Ollama` nodes to get it to apply.

### Changed
- Created `settings.js` to make it easier to work with Griptape Settings for comfyUI.
- Version bump
