### PR TITLE
deprecating Griptape Code: Run Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed 
 ### Security   -->
 
+## [2.1.17] - 2025-27-01
+### Deprecated
+- `Griptape Code: Run Python` node will be removed in a future release due to security concerns over the `exec` command. It's recommended to use the `Griptape Code: Run Griptape Cloude Structure` instead.
+
 ## [2.1.16] - 2025-26-01
 ### Changed
 - Modified RAG code to not use `eval` cmd due to security concerns.

--- a/__init__.py
+++ b/__init__.py
@@ -456,7 +456,7 @@ NODE_CLASS_MAPPINGS = {
     "Griptape Load: Image From URL": gtUIFetchImage,
     # CODE
     "Griptape Code: Run Griptape Cloud Structure": gtUICloudStructureRunTask,
-    "Griptape Code: Run Python": gtUICodeExecutionTask,
+    "Griptape Code: Run Python [DEPRECATED]": gtUICodeExecutionTask,
     # TEXT
     "Griptape Create: Text": gtUIInputStringNode,
     "Griptape Create: CLIP Text Encode": gtUICLIPTextEncode,

--- a/js/nodeFixes.js
+++ b/js/nodeFixes.js
@@ -1,103 +1,158 @@
 export const nodeFixes = {
-    "fixes": {
-        "gtUIInputNode": "Griptape Create: Text",
-        "gtUICLIPTextEncode": "Griptape Create: CLIP Text Encode",
-        "gtUITextToClipEncode": "Griptape Convert: Text to CLIP Encode",
-        "gtUIFetchImage": "Griptape Load: Image From URL",
-        "CreateAgent": "Griptape Create: Agent",
-        "RunAgent": "Griptape Run: Agent",
-        "PromptImageGenerationTask": "Griptape Create: Image from Text",
-        "PromptImageVariationTask": "Griptape Create: Image Variation",
-        "Rule": "Griptape Create: Rules",
-        "RulesList": "Griptape Combine: Rules List",
-        "gtUIOpenAiAudioTranscriptionDriver": "Griptape Driver: OpenAI",
-        "gtUIAmazonBedrockStableDiffusionImageGenerationDriver": "Griptape Driver: Amazon Bedrock Stable Diffusion",
-        "gtUIAmazonBedrockTitanImageGenerationDriver": "Griptape Driver: Amazon Bedrock Titan",
-        "gtUILeonardoImageGenerationDriver": "Griptape Driver: Leonardo.AI",
-        "gtUIOutputStringNode": "Griptape Display: Text",
-        "gtUIOutputImageNode": "Griptape Display: Image",
-        "gtUIOutputArtifactNode": "Griptape Display: Artifact",
-        "ImageQueryTask": "Griptape Run: Image Description",
-        "ParallelImageQueryTask": "Griptape Run: Parallel Image Description",
-        "PromptTask": "Griptape Run: Task",
-        "ToolTask": "Griptape Run: Task",
-        "ToolkitTask": "Griptape Run: Task",
-        "Griptape Run: Prompt Task": "Griptape Run: Task",
-        "Griptape Run: Tool Task": "Griptape Run: Task",
-        "Griptape Run: Toolkit Task": "Griptape Run: Task",
-        "TextSummaryTask": "Griptape Run: Text Summary",
-        "AudioTranscriptionTask": "Griptape Run: Audio Transcription",
-        "ExpandAgent": "Griptape Expand: Agent Nodes",
-        "gtUIOpenAiStructureConfig": "Griptape Agent Config: OpenAI",
-        "gtUIAmazonBedrockStructureConfig": "Griptape Agent Config: Amazon Bedrock",
-        "gtUIGoogleStructureConfig": "Griptape Agent Config: Google",
-        "gtUIAnthropicStructureConfig": "Griptape Agent Config: Anthropic",
-        "gtUIOllamaStructureConfig": "Griptape Agent Config: Ollama",
-        "gtUILMStudioStructureConfig": "Griptape Agent Config: LM Studio",
-        "Calculator": "Griptape Tool: Calculator",
-        "DateTime": "Griptape Tool: DateTime",
-        "WebScraper": "Griptape Tool: WebScraper",
-        "gtUIFileManager": "Griptape Tool: FileManager",
-        "gtAudioTranscriptionClient": "Griptape Tool: Audio Transcription",
-        "gtUIKnowledgeBaseTool": "Griptape Tool: Griptape Cloud KnowledgeBase",
-        "gtUIWebSearch": "Griptape Tool: WebSearch",
-        "ToolList": "Griptape Combine: Tool List",
-        "MergeTexts": "Griptape Combine: Merge Texts",
-        "EnvironmentConfig": "Griptape Config: Environment Variables",
-        "gtUIOpenAiImageGenerationDriver": "Griptape Audio Driver: OpenAI",
-        "gtUILoadAudio": "Griptape Load: Audio",
-        "Griptape Audio Driver: ElevenLabs": "Griptape Text To Speech Driver: ElevenLabs", 
-        "Griptape Audio Driver: OpenAI": "Griptape Audio Transcription Driver: OpenAI",
-        "Griptape Embedding Driver: OpenAI Compatable": "Griptape Embedding Driver: OpenAI Compatible",
-        "Griptape Prompt Driver: OpenAI Compatable": "Griptape Prompt Driver: OpenAI Compatible",
-        "Grptape Driver: Azure OpenAI Image Generation": "Griptape Driver: Azure OpenAI Image Generation",
-        "Griptape Driver: Amazon OpenSearch Vector Store": "Griptape Vector Store Driver: Amazon OpenSearch",
-        "Griptape Driver: Azure MongoDB Vector Store": "Griptape Vector Store Driver: Azure MongoDB",
-        "Griptape Driver: Marqo Vector Store": "Griptape Vector Store Driver: Marqo",
-        "Griptape Driver: MongoDB Atlas Vector Store": "Griptape Vector Store Driver: MongoDB Atlas",
-        "Griptape Driver: Local Vector Store": "Griptape Vector Store Driver: Local",
-        "Griptape Driver: PGVector Vector Store": "Griptape Vector Store Driver: PGVector",
-        "Griptape Driver: Pinecone Vector Store": "Griptape Vector Store Driver: Pinecone",
-        "Griptape Driver: Redis Vector Store": "Griptape Vector Store Driver: Redis",
-        "Griptape Driver: Qdrant Vector Store": "Griptape Vector Store Driver: Qdrant",
-        "Griptape Driver: DuckDuckGo WebSearch": "Griptape WebSearch Driver: DuckDuckGo",
-        "Griptape Driver: Google WebSearch": "Griptape WebSearch Driver: Google",
-        "Griptape Agent Config: Amazon Bedrock [DEPRECIATED]": "Griptape Agent Config: Amazon Bedrock [DEPRECATED]",
-        "Griptape Agent Config: Anthropic [DEPRECIATED]": "Griptape Agent Config: Anthropic [DEPRECATED]",
-        "Griptape Agent Config: Azure OpenAI [DEPRECIATED]": "Griptape Agent Config: Azure OpenAI [DEPRECATED]",
-        "Griptape Agent Config: Google [DEPRECIATED]": "Griptape Agent Config: Google [DEPRECATED]",
-        "Griptape Agent Config: HuggingFace [DEPRECIATED]": "Griptape Agent Config: HuggingFace [DEPRECATED]",
-        "Griptape Agent Config: LM Studio [DEPRECIATED]": "Griptape Agent Config: LM Studio [DEPRECATED]",
-        "Griptape Agent Config: Ollama [DEPRECIATED]": "Griptape Agent Config: Ollama [DEPRECATED]",
-        "Griptape Agent Config: OpenAI Compatible [DEPRECIATED]": "Griptape Agent Config: OpenAI Compatible [DEPRECATED]",
-        "Griptape Agent Config: OpenAI [DEPRECIATED]": "Griptape Agent Config: OpenAI [DEPRECATED]",
-        "Griptape Agent Config: Amazon Bedrock": "Griptape Agent Config: Amazon Bedrock [DEPRECATED]",
-        "Griptape Agent Config: Anthropic": "Griptape Agent Config: Anthropic [DEPRECATED]",
-        "Griptape Agent Config: Azure OpenAI": "Griptape Agent Config: Azure OpenAI [DEPRECATED]",
-        "Griptape Agent Config: Google": "Griptape Agent Config: Google [DEPRECATED]",
-        "Griptape Agent Config: HuggingFace": "Griptape Agent Config: HuggingFace [DEPRECATED]",
-        "Griptape Agent Config: LM Studio": "Griptape Agent Config: LM Studio [DEPRECATED]",
-        "Griptape Agent Config: Ollama": "Griptape Agent Config: Ollama [DEPRECATED]",
-        "Griptape Agent Config: OpenAI Compatible": "Griptape Agent Config: OpenAI Compatible [DEPRECATED]",
-        "Griptape Agent Config: OpenAI": "Griptape Agent Config: OpenAI [DEPRECATED]",
-        "Griptape Agent Config: Amazon Bedrock [DEPRICATED]": "Griptape Agent Config: Amazon Bedrock [DEPRECATED]",
-        "Griptape Agent Config: Anthropic [DEPRICATED]": "Griptape Agent Config: Anthropic [DEPRECATED]",
-        "Griptape Agent Config: Azure OpenAI [DEPRICATED]": "Griptape Agent Config: Azure OpenAI [DEPRECATED]",
-        "Griptape Agent Config: Google [DEPRICATED]": "Griptape Agent Config: Google [DEPRECATED]",
-        "Griptape Agent Config: HuggingFace [DEPRICATED]": "Griptape Agent Config: HuggingFace [DEPRECATED]",
-        "Griptape Agent Config: LM Studio [DEPRICATED]": "Griptape Agent Config: LM Studio [DEPRECATED]",
-        "Griptape Agent Config: Ollama [DEPRICATED]": "Griptape Agent Config: Ollama [DEPRECATED]",
-        "Griptape Agent Config: OpenAI Compatible [DEPRICATED]": "Griptape Agent Config: OpenAI Compatible [DEPRECATED]",
-        "Griptape Agent Config: OpenAI [DEPRICATED]": "Griptape Agent Config: OpenAI [DEPRECATED]",
-        "Griptape Agent Config: Amazon Bedrock [DEPRICATED]": "Griptape Agent Config: Amazon Bedrock [DEPRECATED]",
-        "Griptape Agent Config: Anthropic [DEPRICATED]" : "Griptape Agent Config: Anthropic [DEPRECATED]",
-        "Griptape Agent Config: Azure OpenAI [DEPRICATED]" : "Griptape Agent Config: Azure OpenAI [DEPRECATED]",
-        "Griptape Agent Config: Google [DEPRICATED]" : "Griptape Agent Config: Google [DEPRECATED]",
-        "Griptape Agent Config: HuggingFace [DEPRICATED]" : "Griptape Agent Config: HuggingFace [DEPRECATED]",
-        "Griptape Agent Config: LM Studio [DEPRICATED]" : "Griptape Agent Config: LM Studio [DEPRECATED]",
-        "Griptape Agent Config: Ollama [DEPRICATED]" : "Griptape Agent Config: Ollama [DEPRECATED]",
-        "Griptape Agent Config: OpenAI Compatible [DEPRICATED]" : "Griptape Agent Config: OpenAI Compatible [DEPRECATED]",
-        "Griptape Agent Config: OpenAI [DEPRICATED]" : "Griptape Agent Config: OpenAI [DEPRECATED]",
-        "Griptape Vector Store Driver: Griptape Cloud KnowledgeBase": "Griptape Vector Store Driver: Griptape Cloud"
-    }
-}
+  fixes: {
+    gtUIInputNode: "Griptape Create: Text",
+    gtUICLIPTextEncode: "Griptape Create: CLIP Text Encode",
+    gtUITextToClipEncode: "Griptape Convert: Text to CLIP Encode",
+    gtUIFetchImage: "Griptape Load: Image From URL",
+    CreateAgent: "Griptape Create: Agent",
+    RunAgent: "Griptape Run: Agent",
+    PromptImageGenerationTask: "Griptape Create: Image from Text",
+    PromptImageVariationTask: "Griptape Create: Image Variation",
+    Rule: "Griptape Create: Rules",
+    RulesList: "Griptape Combine: Rules List",
+    gtUIOpenAiAudioTranscriptionDriver: "Griptape Driver: OpenAI",
+    gtUIAmazonBedrockStableDiffusionImageGenerationDriver:
+      "Griptape Driver: Amazon Bedrock Stable Diffusion",
+    gtUIAmazonBedrockTitanImageGenerationDriver:
+      "Griptape Driver: Amazon Bedrock Titan",
+    gtUILeonardoImageGenerationDriver: "Griptape Driver: Leonardo.AI",
+    gtUIOutputStringNode: "Griptape Display: Text",
+    gtUIOutputImageNode: "Griptape Display: Image",
+    gtUIOutputArtifactNode: "Griptape Display: Artifact",
+    ImageQueryTask: "Griptape Run: Image Description",
+    ParallelImageQueryTask: "Griptape Run: Parallel Image Description",
+    PromptTask: "Griptape Run: Task",
+    ToolTask: "Griptape Run: Task",
+    ToolkitTask: "Griptape Run: Task",
+    "Griptape Run: Prompt Task": "Griptape Run: Task",
+    "Griptape Run: Tool Task": "Griptape Run: Task",
+    "Griptape Run: Toolkit Task": "Griptape Run: Task",
+    TextSummaryTask: "Griptape Run: Text Summary",
+    AudioTranscriptionTask: "Griptape Run: Audio Transcription",
+    ExpandAgent: "Griptape Expand: Agent Nodes",
+    gtUIOpenAiStructureConfig: "Griptape Agent Config: OpenAI",
+    gtUIAmazonBedrockStructureConfig: "Griptape Agent Config: Amazon Bedrock",
+    gtUIGoogleStructureConfig: "Griptape Agent Config: Google",
+    gtUIAnthropicStructureConfig: "Griptape Agent Config: Anthropic",
+    gtUIOllamaStructureConfig: "Griptape Agent Config: Ollama",
+    gtUILMStudioStructureConfig: "Griptape Agent Config: LM Studio",
+    Calculator: "Griptape Tool: Calculator",
+    DateTime: "Griptape Tool: DateTime",
+    WebScraper: "Griptape Tool: WebScraper",
+    gtUIFileManager: "Griptape Tool: FileManager",
+    gtAudioTranscriptionClient: "Griptape Tool: Audio Transcription",
+    gtUIKnowledgeBaseTool: "Griptape Tool: Griptape Cloud KnowledgeBase",
+    gtUIWebSearch: "Griptape Tool: WebSearch",
+    ToolList: "Griptape Combine: Tool List",
+    MergeTexts: "Griptape Combine: Merge Texts",
+    EnvironmentConfig: "Griptape Config: Environment Variables",
+    gtUIOpenAiImageGenerationDriver: "Griptape Audio Driver: OpenAI",
+    gtUILoadAudio: "Griptape Load: Audio",
+    "Griptape Audio Driver: ElevenLabs":
+      "Griptape Text To Speech Driver: ElevenLabs",
+    "Griptape Audio Driver: OpenAI":
+      "Griptape Audio Transcription Driver: OpenAI",
+    "Griptape Embedding Driver: OpenAI Compatable":
+      "Griptape Embedding Driver: OpenAI Compatible",
+    "Griptape Prompt Driver: OpenAI Compatable":
+      "Griptape Prompt Driver: OpenAI Compatible",
+    "Grptape Driver: Azure OpenAI Image Generation":
+      "Griptape Driver: Azure OpenAI Image Generation",
+    "Griptape Driver: Amazon OpenSearch Vector Store":
+      "Griptape Vector Store Driver: Amazon OpenSearch",
+    "Griptape Driver: Azure MongoDB Vector Store":
+      "Griptape Vector Store Driver: Azure MongoDB",
+    "Griptape Driver: Marqo Vector Store":
+      "Griptape Vector Store Driver: Marqo",
+    "Griptape Driver: MongoDB Atlas Vector Store":
+      "Griptape Vector Store Driver: MongoDB Atlas",
+    "Griptape Driver: Local Vector Store":
+      "Griptape Vector Store Driver: Local",
+    "Griptape Driver: PGVector Vector Store":
+      "Griptape Vector Store Driver: PGVector",
+    "Griptape Driver: Pinecone Vector Store":
+      "Griptape Vector Store Driver: Pinecone",
+    "Griptape Driver: Redis Vector Store":
+      "Griptape Vector Store Driver: Redis",
+    "Griptape Driver: Qdrant Vector Store":
+      "Griptape Vector Store Driver: Qdrant",
+    "Griptape Driver: DuckDuckGo WebSearch":
+      "Griptape WebSearch Driver: DuckDuckGo",
+    "Griptape Driver: Google WebSearch": "Griptape WebSearch Driver: Google",
+    "Griptape Agent Config: Amazon Bedrock [DEPRECIATED]":
+      "Griptape Agent Config: Amazon Bedrock [DEPRECATED]",
+    "Griptape Agent Config: Anthropic [DEPRECIATED]":
+      "Griptape Agent Config: Anthropic [DEPRECATED]",
+    "Griptape Agent Config: Azure OpenAI [DEPRECIATED]":
+      "Griptape Agent Config: Azure OpenAI [DEPRECATED]",
+    "Griptape Agent Config: Google [DEPRECIATED]":
+      "Griptape Agent Config: Google [DEPRECATED]",
+    "Griptape Agent Config: HuggingFace [DEPRECIATED]":
+      "Griptape Agent Config: HuggingFace [DEPRECATED]",
+    "Griptape Agent Config: LM Studio [DEPRECIATED]":
+      "Griptape Agent Config: LM Studio [DEPRECATED]",
+    "Griptape Agent Config: Ollama [DEPRECIATED]":
+      "Griptape Agent Config: Ollama [DEPRECATED]",
+    "Griptape Agent Config: OpenAI Compatible [DEPRECIATED]":
+      "Griptape Agent Config: OpenAI Compatible [DEPRECATED]",
+    "Griptape Agent Config: OpenAI [DEPRECIATED]":
+      "Griptape Agent Config: OpenAI [DEPRECATED]",
+    "Griptape Agent Config: Amazon Bedrock":
+      "Griptape Agent Config: Amazon Bedrock [DEPRECATED]",
+    "Griptape Agent Config: Anthropic":
+      "Griptape Agent Config: Anthropic [DEPRECATED]",
+    "Griptape Agent Config: Azure OpenAI":
+      "Griptape Agent Config: Azure OpenAI [DEPRECATED]",
+    "Griptape Agent Config: Google":
+      "Griptape Agent Config: Google [DEPRECATED]",
+    "Griptape Agent Config: HuggingFace":
+      "Griptape Agent Config: HuggingFace [DEPRECATED]",
+    "Griptape Agent Config: LM Studio":
+      "Griptape Agent Config: LM Studio [DEPRECATED]",
+    "Griptape Agent Config: Ollama":
+      "Griptape Agent Config: Ollama [DEPRECATED]",
+    "Griptape Agent Config: OpenAI Compatible":
+      "Griptape Agent Config: OpenAI Compatible [DEPRECATED]",
+    "Griptape Agent Config: OpenAI":
+      "Griptape Agent Config: OpenAI [DEPRECATED]",
+    "Griptape Agent Config: Amazon Bedrock [DEPRICATED]":
+      "Griptape Agent Config: Amazon Bedrock [DEPRECATED]",
+    "Griptape Agent Config: Anthropic [DEPRICATED]":
+      "Griptape Agent Config: Anthropic [DEPRECATED]",
+    "Griptape Agent Config: Azure OpenAI [DEPRICATED]":
+      "Griptape Agent Config: Azure OpenAI [DEPRECATED]",
+    "Griptape Agent Config: Google [DEPRICATED]":
+      "Griptape Agent Config: Google [DEPRECATED]",
+    "Griptape Agent Config: HuggingFace [DEPRICATED]":
+      "Griptape Agent Config: HuggingFace [DEPRECATED]",
+    "Griptape Agent Config: LM Studio [DEPRICATED]":
+      "Griptape Agent Config: LM Studio [DEPRECATED]",
+    "Griptape Agent Config: Ollama [DEPRICATED]":
+      "Griptape Agent Config: Ollama [DEPRECATED]",
+    "Griptape Agent Config: OpenAI Compatible [DEPRICATED]":
+      "Griptape Agent Config: OpenAI Compatible [DEPRECATED]",
+    "Griptape Agent Config: OpenAI [DEPRICATED]":
+      "Griptape Agent Config: OpenAI [DEPRECATED]",
+    "Griptape Agent Config: Amazon Bedrock [DEPRICATED]":
+      "Griptape Agent Config: Amazon Bedrock [DEPRECATED]",
+    "Griptape Agent Config: Anthropic [DEPRICATED]":
+      "Griptape Agent Config: Anthropic [DEPRECATED]",
+    "Griptape Agent Config: Azure OpenAI [DEPRICATED]":
+      "Griptape Agent Config: Azure OpenAI [DEPRECATED]",
+    "Griptape Agent Config: Google [DEPRICATED]":
+      "Griptape Agent Config: Google [DEPRECATED]",
+    "Griptape Agent Config: HuggingFace [DEPRICATED]":
+      "Griptape Agent Config: HuggingFace [DEPRECATED]",
+    "Griptape Agent Config: LM Studio [DEPRICATED]":
+      "Griptape Agent Config: LM Studio [DEPRECATED]",
+    "Griptape Agent Config: Ollama [DEPRICATED]":
+      "Griptape Agent Config: Ollama [DEPRECATED]",
+    "Griptape Agent Config: OpenAI Compatible [DEPRICATED]":
+      "Griptape Agent Config: OpenAI Compatible [DEPRECATED]",
+    "Griptape Agent Config: OpenAI [DEPRICATED]":
+      "Griptape Agent Config: OpenAI [DEPRECATED]",
+    "Griptape Vector Store Driver: Griptape Cloud KnowledgeBase":
+      "Griptape Vector Store Driver: Griptape Cloud",
+    "Griptape Code: Run Python": "Griptape Code: Run Python [DEPRECATED]",
+  },
+};

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "comfyui-griptape"
-version = "2.1.16"
+version = "2.1.17"
 description = "Griptape LLM(Large Language Model) Nodes for ComfyUI."
 authors = ["Jason Schleifer <jason.schleifer@gmail.com>"]
 readme = "README.md"
@@ -9,7 +9,7 @@ readme = "README.md"
 [project]
 name = "comfyui-griptape"
 description = "Griptape LLM(Large Language Model) Nodes for ComfyUI."
-version = "2.1.16" 
+version = "2.1.17" 
 license = {file = "LICENSE"}
 dependencies = ["attrs>=24.3.0,<25.0.0", "openai>=1.58.1,<2.0.0", "griptape[all]>=1.1.3", "python-dotenv", "poetry==1.8.5", "griptape-black-forest @ git+https://github.com/griptape-ai/griptape-black-forest.git", "griptape_serper_driver_extension @ git+https://github.com/mertdeveci5/griptape-serper-driver-extension.git"]
 


### PR DESCRIPTION
- `Griptape Code: Run Python` node will be removed in a future release due to security concerns over the `exec` command. It's recommended to use the `Griptape Code: Run Griptape Cloude Structure` instead.
