### PR TITLE
131-add-min_p-and-top_k-for-lmstudio-and-ollama

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed 
 ### Security   -->
 
+## [2.2.11] - 2025-28-02
+### Added
+- Added `min_p` and/or `top_k` to prompt drivers that support them. 
+  
+  - Top-k: Controls the variety of words the AI can choose from. A lower number (like 10) makes responses more focused and predictable, while a higher number (like 50) allows for more creativity and surprise.
+  
+  - Min-p: Sets a quality threshold for word choices. Only words with at least a certain percentage of confidence compared to the best option are considered. Lower values (like 0.05) allow more variety, while higher values (like 0.3) stick closer to the most predictable options.
+
+  For example, if you ask the question "Give me one unexpected use for a paperclip"..
+  - With low top_k/high min_p: You'll get common answers (holding papers, makeshift hook)
+
+  - With high top_k/low min_p: You'll get more creative or unusual answers (lockpick, tiny sculpture material)
+
+  ℹ️ Note: Some models take `top_p` instead of `min_p`. To keep the parameters persistent, I'm still using `min_p` in the node, but setting it to `1-min_p`, so it _acts_ like `top_p`.
+
+
 ## [2.2.10] - 2025-27-02
 ### Added
 - Added ability to use key value pair replacement with Griptape Cloud Assistant as well.

--- a/nodes/drivers/gtUIAmazonBedrockPromptDriver.py
+++ b/nodes/drivers/gtUIAmazonBedrockPromptDriver.py
@@ -104,7 +104,8 @@ class gtUIAmazonBedrockPromptDriver(gtUIBasePromptDriver):
             params["aws_secret_access_key"] = secret_access_key
         if api_key:
             params["aws_access_key_id"] = api_key
-
+        params["min_p"] = kwargs.get("min_p", 0.1)
+        params["top_k"] = kwargs.get("top_k", 40)
         return params
 
     def create(self, **kwargs):

--- a/nodes/drivers/gtUIAmazonSageMakerJumpstartPromptDriver.py
+++ b/nodes/drivers/gtUIAmazonSageMakerJumpstartPromptDriver.py
@@ -18,6 +18,8 @@ class gtUIAmazonSageMakerJumpstartPromptDriver(gtUIBasePromptDriver):
         inputs = super().INPUT_TYPES()
 
         inputs["required"].update()
+        del inputs["optional"]["min_p"]
+        del inputs["optional"]["top_k"]
         inputs["optional"].update(
             {
                 "model": (
@@ -100,6 +102,7 @@ class gtUIAmazonSageMakerJumpstartPromptDriver(gtUIBasePromptDriver):
             params["endpoint"] = endpoint
         if use_native_tools:
             params["use_native_tools"] = use_native_tools
+
         try:
             driver = AmazonSageMakerJumpstartPromptDriver(**params)
             return (driver,)

--- a/nodes/drivers/gtUIAnthropicPromptDriver.py
+++ b/nodes/drivers/gtUIAnthropicPromptDriver.py
@@ -23,7 +23,7 @@ class gtUIAnthropicPromptDriver(gtUIBasePromptDriver):
 
         # Add the optional inputs
         inputs["optional"].update(base_optional_inputs)
-
+        del inputs["optional"]["min_p"]
         # Set model default
         inputs["optional"]["model"] = (
             models,

--- a/nodes/drivers/gtUIAzureOpenAiChatPromptDriver.py
+++ b/nodes/drivers/gtUIAzureOpenAiChatPromptDriver.py
@@ -27,6 +27,8 @@ class gtUIAzureOpenAiChatPromptDriver(gtUIBasePromptDriver):
 
         # Add the optional inputs
         inputs["optional"].update(base_optional_inputs)
+        del inputs["optional"]["min_p"]
+        del inputs["optional"]["top_k"]
         inputs["optional"].update(
             {
                 "model": (models, {"default": models[0]}),
@@ -78,6 +80,10 @@ class gtUIAzureOpenAiChatPromptDriver(gtUIBasePromptDriver):
             "temperature": temperature,
             "max_attempts": max_attempts_on_fail,
             "use_native_tools": use_native_tools,
+            # "extra_params": {
+            #     # "min_p": min_p,
+            #     "top_k": top_k,
+            # },
         }
         if response_format == "json_object":
             response_format = {"type": "json_object"}

--- a/nodes/drivers/gtUIBasePromptDriver.py
+++ b/nodes/drivers/gtUIBasePromptDriver.py
@@ -55,6 +55,23 @@ class gtUIBasePromptDriver(gtUIBaseDriver):
                         "tooltip": "Maximum tokens to generate. If <=0, it will use the default based on the tokenizer.",
                     },
                 ),
+                "min_p": (
+                    "FLOAT",
+                    {
+                        "default": 0.1,
+                        "min": 0.0,
+                        "max": 1.0,
+                        "step": 0.01,
+                        "tooltip": "Minimum probability for sampling. Lower values will be more random.",
+                    },
+                ),
+                "top_k": (
+                    "INT",
+                    {
+                        "default": 40,
+                        "tooltip": "Top k for sampling. Lower values are more deterministic.",
+                    },
+                ),
             },
         )
         return inputs

--- a/nodes/drivers/gtUICoherePromptDriver.py
+++ b/nodes/drivers/gtUICoherePromptDriver.py
@@ -51,11 +51,17 @@ class gtUICoherePromptDriver(gtUIBasePromptDriver):
         max_attempts = kwargs.get("max_attempts_on_fail", None)
         use_native_tools = kwargs.get("use_native_tools", False)
         max_tokens = kwargs.get("max_tokens", None)
+        min_p = kwargs.get("min_p", None)
+        top_k = kwargs.get("top_k", None)
         params = {
             "api_key": api_key,
             "model": model,
             "max_attempts": max_attempts,
             "use_native_tools": use_native_tools,
+            "extra_params": {
+                "p": 1 - min_p,
+                "k": top_k,
+            },
         }
         if max_tokens > 0:
             params["max_tokens"] = max_tokens

--- a/nodes/drivers/gtUIGooglePromptDriver.py
+++ b/nodes/drivers/gtUIGooglePromptDriver.py
@@ -18,7 +18,7 @@ class gtUIGooglePromptDriver(gtUIBasePromptDriver):
     @classmethod
     def INPUT_TYPES(cls):
         inputs = super().INPUT_TYPES()
-
+        del inputs["optional"]["min_p"]
         inputs["optional"].update(
             {
                 "model": (models, {"default": models[0]}),

--- a/nodes/drivers/gtUIGriptapeCloudPromptDriver.py
+++ b/nodes/drivers/gtUIGriptapeCloudPromptDriver.py
@@ -28,7 +28,7 @@ class gtUIGriptapeCloudPromptDriver(gtUIBasePromptDriver):
 
         # Add the optional inputs
         inputs["optional"].update(base_optional_inputs)
-
+        del inputs["optional"]["top_k"]
         # Set model default
         inputs["optional"]["model"] = (models, {"default": DEFAULT_MODEL})
         inputs["optional"].update(
@@ -83,6 +83,7 @@ class gtUIGriptapeCloudPromptDriver(gtUIBasePromptDriver):
             params["use_native_tools"] = use_native_tools
         if max_tokens > 0:
             params["max_tokens"] = max_tokens
+        params["extra_params"]["top_p"] = 1 - kwargs.get("min_p", None)
 
         return params
 

--- a/nodes/drivers/gtUIGrokPromptDriver.py
+++ b/nodes/drivers/gtUIGrokPromptDriver.py
@@ -29,6 +29,8 @@ class gtUIGrokPromptDriver(gtUIBasePromptDriver):
         # Add the optional inputs
         inputs["optional"].update(base_optional_inputs)
 
+        del inputs["optional"]["top_k"]
+
         # Set model default
         inputs["optional"]["model"] = (models, {"default": DEFAULT_MODEL})
         inputs["optional"].update(
@@ -83,6 +85,7 @@ class gtUIGrokPromptDriver(gtUIBasePromptDriver):
             params["use_native_tools"] = use_native_tools
         if max_tokens > 0:
             params["max_tokens"] = max_tokens
+        params["extra_params"]["top_p"] = 1 - kwargs.get("min_p", None)
 
         return params
 

--- a/nodes/drivers/gtUIGroqChatPromptDriver.py
+++ b/nodes/drivers/gtUIGroqChatPromptDriver.py
@@ -77,6 +77,10 @@ class gtUIGroqChatPromptDriver(gtUIOpenAiCompatibleChatPromptDriver):
             "temperature": temperature,
             "use_native_tools": use_native_tools,
             "max_attempts": max_attempts,
+            "modalities": [],
+            "extra_params": {
+                "top_p": 1 - kwargs.get("min_p", None),
+            },
         }
         if response_format == "json_object":
             params["response_format"] = {"type": response_format}

--- a/nodes/drivers/gtUIHuggingFaceHubPromptDriver.py
+++ b/nodes/drivers/gtUIHuggingFaceHubPromptDriver.py
@@ -15,6 +15,8 @@ class gtUIHuggingFaceHubPromptDriver(gtUIBasePromptDriver):
         inputs = super().INPUT_TYPES()
 
         inputs["required"].update({})
+        del inputs["optional"]["min_p"]
+        del inputs["optional"]["top_k"]
         inputs["optional"].update(
             {
                 "model": (

--- a/nodes/drivers/gtUILMStudioChatPromptDriver.py
+++ b/nodes/drivers/gtUILMStudioChatPromptDriver.py
@@ -69,7 +69,7 @@ class gtUILMStudioChatPromptDriver(gtUIOpenAiCompatibleChatPromptDriver):
         max_attempts = kwargs.get("max_attempts_on_fail", None)
         use_native_tools = kwargs.get("use_native_tools", False)
         max_tokens = kwargs.get("max_tokens", None)
-
+        top_p = 1 - kwargs.get("min_p", None)
         params = {
             "model": model,
             "base_url": f"{base_url}:{port}/v1",
@@ -77,6 +77,10 @@ class gtUILMStudioChatPromptDriver(gtUIOpenAiCompatibleChatPromptDriver):
             "temperature": temperature,
             "use_native_tools": use_native_tools,
             "max_attempts": max_attempts,
+            "extra_params": {
+                "top_p": top_p,
+                # "top_k": top_k,
+            },
         }
         if response_format == "json_object":
             params["response_format"] = {"type": response_format}

--- a/nodes/drivers/gtUIOllamaPromptDriver.py
+++ b/nodes/drivers/gtUIOllamaPromptDriver.py
@@ -85,7 +85,8 @@ class gtUIOllamaPromptDriver(gtUIBasePromptDriver):
         use_native_tools = kwargs.get("use_native_tools", False)
         max_tokens = kwargs.get("max_tokens", None)
         keep_alive = kwargs.get("keep_alive", 240)
-
+        min_p = kwargs.get("min_p")
+        top_k = kwargs.get("top_k")
         params = {
             "model": model,
             "temperature": temperature,
@@ -96,7 +97,13 @@ class gtUIOllamaPromptDriver(gtUIBasePromptDriver):
             params["host"] = f"{base_url}:{port}"
         if max_tokens > 0:
             params["max_tokens"] = max_tokens
-        params["extra_params"] = {"keep_alive": int(keep_alive)}
+        params["extra_params"] = {
+            "keep_alive": int(keep_alive),
+            "options": {
+                "min_p": min_p,
+                "top_k": top_k,
+            },
+        }
         return params
 
     def create(self, **kwargs):

--- a/nodes/drivers/gtUIOpenAiChatPromptDriver.py
+++ b/nodes/drivers/gtUIOpenAiChatPromptDriver.py
@@ -32,6 +32,8 @@ class gtUIOpenAiChatPromptDriver(gtUIBasePromptDriver):
         # Add the optional inputs
         inputs["optional"].update(base_optional_inputs)
 
+        del inputs["optional"]["top_k"]
+
         # Set model default
         inputs["optional"]["model"] = (models, {"default": DEFAULT_MODEL})
         inputs["optional"].update(
@@ -85,7 +87,9 @@ class gtUIOpenAiChatPromptDriver(gtUIBasePromptDriver):
             params["use_native_tools"] = use_native_tools
         if max_tokens > 0:
             params["max_tokens"] = max_tokens
-
+        params["extra_params"] = {
+            "top_p": 1 - kwargs.get("min_p", None),
+        }
         return params
 
     def create(self, **kwargs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "comfyui-griptape"
-version = "2.2.10"
+version = "2.2.11"
 description = "Griptape LLM(Large Language Model) Nodes for ComfyUI."
 authors = ["Jason Schleifer <jason.schleifer@gmail.com>"]
 readme = "README.md"
@@ -9,7 +9,7 @@ readme = "README.md"
 [project]
 name = "comfyui-griptape"
 description = "Griptape LLM(Large Language Model) Nodes for ComfyUI."
-version = "2.2.10" 
+version = "2.2.11" 
 license = {file = "LICENSE"}
 dependencies = ["attrs>=24.3.0,<26.0.0", "openai>=1.58.1,<2.0.0", "griptape[all]>=1.4.0", "python-dotenv", "poetry==1.8.5", "griptape-black-forest @ git+https://github.com/griptape-ai/griptape-black-forest.git", "griptape_serper_driver_extension @ git+https://github.com/mertdeveci5/griptape-serper-driver-extension.git"]
 


### PR DESCRIPTION
### Added
- Added `min_p` and/or `top_k` to prompt drivers that support them. 
  
  - Top-k: Controls the variety of words the AI can choose from. A lower number (like 10) makes responses more focused and predictable, while a higher number (like 50) allows for more creativity and surprise.
  
  - Min-p: Sets a quality threshold for word choices. Only words with at least a certain percentage of confidence compared to the best option are considered. Lower values (like 0.05) allow more variety, while higher values (like 0.3) stick closer to the most predictable options.

  For example, if you ask the question "Give me one unexpected use for a paperclip"..
  - With low top_k/high min_p: You'll get common answers (holding papers, makeshift hook)

  - With high top_k/low min_p: You'll get more creative or unusual answers (lockpick, tiny sculpture material)

  ℹ️ Note: Some models take `top_p` instead of `min_p`. To keep the parameters persistent, I'm still using `min_p` in the node, but setting it to `1-min_p`, so it _acts_ like `top_p`.
