### PR TITLE
Fix/mergeTexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed 
 ### Security   -->
 
+## [2.2.13] - 2025-01-05
+### Fixed
+- Something changed in how ComfyUI was handling STRING inputs which caused the `Griptape Combine: Merge Text` node to break. Modified the input to handle * instead of only STRING, which fixes it.
+
 ## [2.2.12] - 2025-01-03
 ### Added
 - Added `Griptape Display: Text as Markdown` node.

--- a/nodes/combine/MergeTexts.py
+++ b/nodes/combine/MergeTexts.py
@@ -13,16 +13,16 @@ class MergeTexts:
         return {
             "required": {},
             "optional": {
-                "merge_string": ("STRING", {"default": "\\n\\n"}),
                 "input_1": (
-                    "STRING",
+                    "*",
                     {
                         "multiline": False,
-                        "default": "",
+                        # "default": "",
                         "forceInput": True,
                         "tooltip": "A text input to merge. Connect an input to dynamically create more inputs.",
                     },
                 ),
+                "merge_string": ("STRING", {"default": "\\n\\n"}),
             },
         }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "comfyui-griptape"
-version = "2.2.12"
+version = "2.2.13"
 description = "Griptape LLM(Large Language Model) Nodes for ComfyUI."
 authors = ["Jason Schleifer <jason.schleifer@gmail.com>"]
 readme = "README.md"
@@ -9,7 +9,7 @@ readme = "README.md"
 [project]
 name = "comfyui-griptape"
 description = "Griptape LLM(Large Language Model) Nodes for ComfyUI."
-version = "2.2.12" 
+version = "2.2.13" 
 license = {file = "LICENSE"}
 dependencies = ["attrs>=24.3.0,<26.0.0", "openai>=1.58.1,<2.0.0", "griptape[all]>=1.4.0", "python-dotenv", "poetry==1.8.5", "griptape-black-forest @ git+https://github.com/griptape-ai/griptape-black-forest.git", "griptape_serper_driver_extension @ git+https://github.com/mertdeveci5/griptape-serper-driver-extension.git"]
 


### PR DESCRIPTION
- Something changed in how ComfyUI was handling STRING inputs which caused the `Griptape Combine: Merge Text` node to break. Modified the input to handle * instead of only STRING, which fixes it.
